### PR TITLE
feat: add Aethera legal pages and migrate site domain to n33no.online

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -168,7 +168,7 @@ public/
 ## 🔗 Enlaces Útiles
 
 - [GitHub Actions](https://github.com/aarjona1991/aarjona1991.github.io/actions)
-- [GitHub Pages](https://aarjona1991.github.io/)
+- [Sitio en producción](https://n33no.online/)
 - [Configuración de Pages](https://github.com/aarjona1991/aarjona1991.github.io/settings/pages)
 
 ## 📞 Soporte

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+n33no.online

--- a/public/_config.yml
+++ b/public/_config.yml
@@ -3,7 +3,7 @@ title: aarjona1991 - Frontend Developer Portfolio
 description: Professional Frontend Developer specialized in React, TypeScript, and modern web technologies
 author: aarjona1991
 email: aarjona1991@gmail.com
-url: https://aarjona1991.github.io
+url: https://n33no.online
 baseurl: ""
 
 # SEO Configuration

--- a/public/_redirects
+++ b/public/_redirects
@@ -9,3 +9,12 @@
 /privacy-policy    /privacy-policy.html    200
 /privacy-policy-es    /privacy-policy-es.html    200
 /privacy-policy-en    /privacy-policy-en.html    200
+
+# Aethera app (Google Play) legal pages — devguy/com.devguy.aethera
+/devguy/aethera/privacy    /devguy/aethera/privacy-policy.html    200
+/devguy/aethera/privacy-en    /devguy/aethera/privacy-policy-en.html    200
+/devguy/aethera/terms    /devguy/aethera/terms.html    200
+/devguy/aethera/terms-en    /devguy/aethera/terms-en.html    200
+
+# Backward-compatible redirects from the old /aethera/ path
+/aethera/*    /devguy/aethera/:splat    301

--- a/public/build-config.json
+++ b/public/build-config.json
@@ -12,7 +12,7 @@
   ],
   "author": "aarjona1991",
   "license": "MIT",
-  "homepage": "https://aarjona1991.github.io",
+  "homepage": "https://n33no.online",
   "repository": {
     "type": "git",
     "url": "https://github.com/aarjona1991/aarjona1991.github.io.git"

--- a/public/devguy/aethera/privacy-policy-en.html
+++ b/public/devguy/aethera/privacy-policy-en.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
+    <title>Privacy Policy — Aethera</title>
+    <meta name="description" content="Privacy policy for the Aethera app: what health, location and account data is collected, how it is used, who it is shared with, and how to delete it.">
+    <link rel="canonical" href="https://n33no.online/devguy/aethera/privacy-policy-en.html">
+    <link rel="alternate" hreflang="es" href="https://n33no.online/devguy/aethera/privacy-policy.html">
+    <link rel="alternate" hreflang="en" href="https://n33no.online/devguy/aethera/privacy-policy-en.html">
+    <link rel="stylesheet" href="/styles/output.css">
+    <script>
+        if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark')
+        }
+    </script>
+</head>
+<body class="dark:bg-gray-900 antialiased">
+    <div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+
+                <div class="flex items-center justify-between mb-6">
+                    <span class="text-sm font-semibold tracking-wide text-blue-600 dark:text-blue-400 uppercase">Aethera</span>
+                    <a href="/devguy/aethera/privacy-policy.html" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">Versión en español</a>
+                </div>
+
+                <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-2">
+                    Privacy Policy
+                </h1>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                    <strong>Aethera</strong> mobile app (Android) · Package ID: <code>com.devguy.aethera</code>
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-8">
+                    Last updated: May 28, 2026 · Effective: May 28, 2026
+                </p>
+
+                <div class="bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-400 p-4 mb-4">
+                    <p class="text-blue-800 dark:text-blue-200">
+                        <strong>Summary:</strong> Aethera is a <strong>personal wellness</strong> app (biorhythm, numerology, weather, mood, sleep and, optionally, wearable data). Your data is processed mainly <strong>on your device</strong>. We only access health data you explicitly authorize, we never sell it or use it for advertising, and you can revoke access or delete it at any time.
+                    </p>
+                </div>
+
+                <div class="bg-amber-50 dark:bg-amber-900/20 border-l-4 border-amber-400 p-4 mb-8">
+                    <p class="text-amber-800 dark:text-amber-200">
+                        <strong>Important notice:</strong> Aethera <strong>is not a medical application</strong> and does not diagnose, treat or prevent any disease. The information it provides is for informational and wellness purposes only and is not a substitute for professional medical advice.
+                    </p>
+                </div>
+
+                <div class="prose prose-lg max-w-none dark:prose-invert">
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">1. Data controller</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        The data controller is <strong>Adrian Arjona Clavelo</strong> (independent developer of Aethera), based in Montevideo, Uruguay. You can contact us at any time at <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a>.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">2. Data we collect</h2>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.1 Account and profile data</h3>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>Google sign-in (optional):</strong> name, email address, profile photo and user ID, via Firebase Authentication.</li>
+                        <li><strong>Wellness profile:</strong> name, <strong>date of birth</strong> (to compute biorhythm, numerology and zodiac sign) and app preferences.</li>
+                    </ul>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.2 Health and fitness data</h3>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        Only with your explicit authorization, Aethera reads the following data through <strong>Health Connect</strong> and/or your band/watch over <strong>Bluetooth (BLE)</strong>:
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Steps and distance</li>
+                        <li>Sleep (duration and stages, depending on the device)</li>
+                        <li>Heart rate and resting heart rate</li>
+                        <li>Exercise and active calories</li>
+                        <li>Blood oxygen (SpO₂), stress level and wearable battery (when the device provides them)</li>
+                    </ul>
+                    <p class="text-gray-700 dark:text-gray-300 mt-2">
+                        This data comes from Health Connect or from your wearable's apps (e.g. Mi Fitness, Google Fit or others you authorize). Aethera <strong>only reads</strong> this data; it <strong>never writes</strong> to Health Connect.
+                    </p>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.3 Microphone (ambient noise measurement)</h3>
+                    <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-400 p-4 mb-4">
+                        <p class="text-green-800 dark:text-green-200">
+                            In the Sleep Assistant, and only with your permission, the microphone is used solely to <strong>measure the ambient noise level (decibels)</strong> and assess your rest environment. Audio is processed in real time on the device and is <strong>never recorded, stored or transmitted</strong> to any server.
+                        </p>
+                    </div>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.4 Location</h3>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>Approximate or precise location:</strong> used only to retrieve the weather forecast for your area. You may deny this permission and the app will keep working.</li>
+                    </ul>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.5 Data generated in the app</h3>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Mood and sleep check-ins and any notes you write.</li>
+                        <li>Settings, reminders, notifications and theme/language preferences.</li>
+                        <li>Subscription status (Aethera Plus) according to Google Play.</li>
+                    </ul>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.6 Technical and usage data</h3>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Usage events and basic device information via <strong>Firebase Analytics</strong>, to understand feature usage and improve the app.</li>
+                        <li>Technical error logs to diagnose crashes.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">3. How we use your data</h2>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Personalize your daily wellness guidance (biorhythm, numerology, weather and, when available, wearable signals).</li>
+                        <li>Generate sleep recommendations and assess your rest environment.</li>
+                        <li>Show the weather for your location.</li>
+                        <li>Send the notifications and reminders you enable.</li>
+                        <li>Manage the Aethera Plus subscription and its features.</li>
+                        <li>Improve the performance, stability and experience of the app.</li>
+                    </ul>
+                    <p class="text-gray-700 dark:text-gray-300 mt-4">
+                        We do <strong>not</strong> use your health or fitness data for advertising, we do not sell it, and we do not use it to build marketing profiles.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">4. Artificial intelligence processing</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        To generate the daily guidance, Aethera sends a <strong>small set of aggregated signals</strong> (biorhythm percentages, the day's numerology number, weather data and a non-identifiable summary of wearable metrics such as sleep minutes or recent heart rate) to an AI provider (Google Gemini or Ollama) through a <strong>secure backend</strong> managed by the developer.
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Your identity, email or raw health records are not sent.</li>
+                        <li>Communications are encrypted (HTTPS/TLS) and keys are not embedded in the app.</li>
+                        <li>If you do not use the AI guidance feature, none of these signals are sent.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">5. Health Connect</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        Aethera's use of data obtained through Health Connect complies with the <a href="https://developer.android.com/health-and-fitness/health-connect/data-and-data-types/data-management" class="text-blue-600 dark:text-blue-400 hover:underline">Health Connect permissions policy</a> and the Google Play User Data policy, including the limited-use requirement:
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>We only request the data types needed for the wellness and sleep features you use.</li>
+                        <li>Aethera <strong>only reads</strong> data from Health Connect; it does not write or modify data.</li>
+                        <li>Health data is <strong>not transferred to third parties</strong> except to provide the requested feature, and is never used for advertising or sold.</li>
+                        <li>You can revoke access at any time from Health Connect or your system settings.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">6. Where your data is stored</h2>
+                    <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-400 p-4 mb-4">
+                        <p class="text-green-800 dark:text-green-200">
+                            <strong>On your device:</strong> most data (mood and sleep history, the latest wearable summary, the daily guidance cache, preferences) is stored locally in the app's local database and preference storage.
+                        </p>
+                    </div>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>Firebase (Authentication and Firestore):</strong> if you sign in, your user ID and basic profile data are stored for syncing.</li>
+                        <li><strong>Developer backend and AI/weather providers:</strong> temporarily process the aggregated signals to return guidance or the forecast; they are not used to identify you.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">7. Who we share data with</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        We do not sell or rent your personal data. We share the minimum necessary with the following <strong>processors</strong>, solely so the app can work:
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>Google Firebase</strong> (Authentication, Firestore, Analytics): account, profile and usage metrics.</li>
+                        <li><strong>Google Play Billing</strong>: subscription management. Google processes the payment; <strong>we do not store card data</strong>.</li>
+                        <li><strong>Weather provider</strong> (through our backend): approximate coordinates for the forecast.</li>
+                        <li><strong>AI provider</strong> (Google Gemini or Ollama, through our backend): aggregated signals for the daily guidance.</li>
+                    </ul>
+                    <p class="text-gray-700 dark:text-gray-300 mt-2">
+                        We may also disclose data where required by law. Health data is never shared for advertising purposes.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">8. Retention and deletion</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        We keep data while you use the app or maintain your account. You can delete your data as follows:
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>On-device data:</strong> delete it from the app's Settings or by uninstalling Aethera.</li>
+                        <li><strong>Health access:</strong> revoke permissions in Health Connect or disconnect the wearable from the app.</li>
+                        <li><strong>Account and Firebase data:</strong> email <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a> requesting account deletion and we will handle it within a reasonable timeframe.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">9. Security</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        We apply reasonable security measures: encrypted connections (HTTPS/TLS), certificate pinning to our backend, API keys not embedded in the app, and data minimization. No system is 100% foolproof, but we work to protect your information.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">10. Your rights</h2>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Access, correct or delete your data.</li>
+                        <li>Withdraw your consent (revoke health, location or microphone permissions).</li>
+                        <li>Object to or restrict certain processing and request data portability.</li>
+                        <li>File a complaint with your data protection authority.</li>
+                    </ul>
+                    <p class="text-gray-700 dark:text-gray-300 mt-2">
+                        To exercise these rights (including GDPR in the EU/EEA and CCPA in California), email us at <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a>.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">11. International transfers</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        Some providers (such as Google) may process data on servers located outside your country. In those cases, the relevant safeguards offered by those providers apply.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">12. Children</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        Aethera is not directed to children under 13 (or under 16 in the EEA where applicable). We do not knowingly collect data from children. If you believe a child has provided us with data, contact us so we can delete it.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">13. Changes to this policy</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        We may update this policy. We will post changes at this same URL and update the "Last updated" date. Significant changes will be communicated in the app where appropriate.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">14. Contact</h2>
+                    <div class="bg-gray-50 dark:bg-gray-700 p-6 rounded-lg">
+                        <p class="text-gray-700 dark:text-gray-300 mb-4">
+                            If you have questions about this privacy policy or how your data is handled:
+                        </p>
+                        <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+                            <li><strong>Email:</strong> <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a></li>
+                            <li><strong>App:</strong> Aethera (<code>com.devguy.aethera</code>)</li>
+                            <li><strong>Terms of Service:</strong> <a href="/devguy/aethera/terms-en.html" class="text-blue-600 dark:text-blue-400 hover:underline">n33no.online/devguy/aethera/terms-en.html</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+                        <p class="text-sm text-gray-500 dark:text-gray-400 text-center">
+                            This privacy policy is effective as of May 28, 2026.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/public/devguy/aethera/privacy-policy.html
+++ b/public/devguy/aethera/privacy-policy.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
+    <title>Política de Privacidad — Aethera</title>
+    <meta name="description" content="Política de privacidad de la aplicación Aethera: qué datos de salud, ubicación y cuenta se recopilan, cómo se usan, con quién se comparten y cómo eliminarlos.">
+    <link rel="canonical" href="https://n33no.online/devguy/aethera/privacy-policy.html">
+    <link rel="alternate" hreflang="es" href="https://n33no.online/devguy/aethera/privacy-policy.html">
+    <link rel="alternate" hreflang="en" href="https://n33no.online/devguy/aethera/privacy-policy-en.html">
+    <link rel="stylesheet" href="/styles/output.css">
+    <script>
+        // Evitar parpadeo de tema (FOUC) antes de cargar estilos
+        if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark')
+        }
+    </script>
+</head>
+<body class="dark:bg-gray-900 antialiased">
+    <div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+
+                <div class="flex items-center justify-between mb-6">
+                    <span class="text-sm font-semibold tracking-wide text-blue-600 dark:text-blue-400 uppercase">Aethera</span>
+                    <a href="/devguy/aethera/privacy-policy-en.html" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">English version</a>
+                </div>
+
+                <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-2">
+                    Política de Privacidad
+                </h1>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                    Aplicación móvil <strong>Aethera</strong> (Android) · Identificador del paquete: <code>com.devguy.aethera</code>
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-8">
+                    Última actualización: 28 de mayo de 2026 · Vigente desde: 28 de mayo de 2026
+                </p>
+
+                <div class="bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-400 p-4 mb-4">
+                    <p class="text-blue-800 dark:text-blue-200">
+                        <strong>Resumen:</strong> Aethera es una app de <strong>bienestar personal</strong> (biorritmo, numerología, clima, estado de ánimo, sueño y, opcionalmente, datos de wearables). Tus datos se procesan principalmente <strong>en tu dispositivo</strong>. Solo accedemos a datos de salud que tú autorizas expresamente, no los vendemos ni los usamos para publicidad, y puedes revocar el acceso o eliminarlos en cualquier momento.
+                    </p>
+                </div>
+
+                <div class="bg-amber-50 dark:bg-amber-900/20 border-l-4 border-amber-400 p-4 mb-8">
+                    <p class="text-amber-800 dark:text-amber-200">
+                        <strong>Aviso importante:</strong> Aethera <strong>no es una aplicación médica</strong> y no diagnostica, trata ni previene enfermedades. La información que ofrece es de carácter informativo y de bienestar, y no sustituye el consejo de un profesional de la salud.
+                    </p>
+                </div>
+
+                <div class="prose prose-lg max-w-none dark:prose-invert">
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">1. Responsable del tratamiento</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        El responsable del tratamiento de los datos es <strong>Adrian Arjona Clavelo</strong> (desarrollador independiente de Aethera), con domicilio en Montevideo, Uruguay. Puedes contactarnos en cualquier momento en <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a>.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">2. Datos que recopilamos</h2>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.1 Datos de cuenta y perfil</h3>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>Inicio de sesión con Google (opcional):</strong> nombre, dirección de correo electrónico, foto de perfil e identificador de usuario, a través de Firebase Authentication.</li>
+                        <li><strong>Perfil de bienestar:</strong> nombre, <strong>fecha de nacimiento</strong> (para calcular biorritmo, numerología y signo astrológico) y preferencias de la app.</li>
+                    </ul>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.2 Datos de salud y actividad física</h3>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        Solo si lo autorizas expresamente, Aethera lee los siguientes datos a través de <strong>Health Connect</strong> y/o de tu pulsera/reloj por <strong>Bluetooth (BLE)</strong>:
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Pasos y distancia recorrida</li>
+                        <li>Sueño (duración y fases, según el dispositivo)</li>
+                        <li>Frecuencia cardiaca y frecuencia cardiaca en reposo</li>
+                        <li>Ejercicio y calorías activas</li>
+                        <li>Saturación de oxígeno (SpO₂), nivel de estrés y batería del wearable (cuando el dispositivo lo proporciona)</li>
+                    </ul>
+                    <p class="text-gray-700 dark:text-gray-300 mt-2">
+                        Estos datos provienen de Health Connect o de apps de tu wearable (por ejemplo, Mi Fitness, Google Fit u otras que tú autorices). Aethera <strong>solo lee</strong> estos datos; <strong>nunca escribe</strong> en Health Connect.
+                    </p>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.3 Micrófono (medición de ruido del entorno)</h3>
+                    <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-400 p-4 mb-4">
+                        <p class="text-green-800 dark:text-green-200">
+                            En el Asistente de Sueño, y solo con tu permiso, el micrófono se usa exclusivamente para <strong>medir el nivel de ruido ambiental (decibelios)</strong> y evaluar tu entorno de descanso. El audio se procesa en tiempo real en el dispositivo y <strong>no se graba, no se almacena y no se transmite</strong> a ningún servidor.
+                        </p>
+                    </div>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.4 Ubicación</h3>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>Ubicación aproximada o precisa:</strong> se usa únicamente para obtener el pronóstico del clima de tu zona. Puedes denegar este permiso y la app seguirá funcionando.</li>
+                    </ul>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.5 Datos generados en la app</h3>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Registros de estado de ánimo y de sueño (check-ins) y notas que escribas.</li>
+                        <li>Ajustes, recordatorios, notificaciones y preferencias de tema/idioma.</li>
+                        <li>Estado de la suscripción (Aethera Plus) según Google Play.</li>
+                    </ul>
+
+                    <h3 class="text-xl font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">2.6 Datos técnicos y de uso</h3>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Eventos de uso e información básica del dispositivo a través de <strong>Firebase Analytics</strong>, para entender el uso de las funciones y mejorar la app.</li>
+                        <li>Registros técnicos de errores para diagnosticar fallos.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">3. Para qué usamos tus datos</h2>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Personalizar tu guía diaria de bienestar (biorritmo, numerología, clima y, si están disponibles, señales de tu wearable).</li>
+                        <li>Generar recomendaciones de sueño y evaluar el entorno de descanso.</li>
+                        <li>Mostrar el clima de tu ubicación.</li>
+                        <li>Enviar notificaciones y recordatorios que actives.</li>
+                        <li>Gestionar la suscripción Aethera Plus y sus funciones.</li>
+                        <li>Mejorar el rendimiento, la estabilidad y la experiencia de la app.</li>
+                    </ul>
+                    <p class="text-gray-700 dark:text-gray-300 mt-4">
+                        <strong>No</strong> usamos tus datos de salud ni de actividad física con fines publicitarios, ni los vendemos, ni los empleamos para crear perfiles con fines de marketing.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">4. Procesamiento por inteligencia artificial</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        Para generar la guía diaria, Aethera envía un <strong>conjunto reducido de señales agregadas</strong> (porcentajes de biorritmo, número de numerología del día, datos del clima y un resumen no identificable de métricas del wearable, como minutos de sueño o pulso reciente) a un proveedor de IA (Google Gemini u Ollama) a través de un <strong>backend seguro</strong> gestionado por el desarrollador.
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>No se envía tu identidad, tu correo, ni registros de salud sin procesar.</li>
+                        <li>Las comunicaciones viajan cifradas (HTTPS/TLS) y las claves no se incluyen en la app.</li>
+                        <li>Si no usas la función de guía por IA, no se envía ninguna de estas señales.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">5. Health Connect</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        El uso que Aethera hace de los datos obtenidos a través de Health Connect cumple la <a href="https://developer.android.com/health-and-fitness/health-connect/data-and-data-types/data-management" class="text-blue-600 dark:text-blue-400 hover:underline">Política de permisos de Health Connect</a> y la Política de Datos de Usuario de Google Play, incluyendo el requisito de uso limitado:
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Solo solicitamos los tipos de datos necesarios para las funciones de bienestar y sueño que usas.</li>
+                        <li>Aethera <strong>solo lee</strong> datos de Health Connect; no escribe ni modifica datos.</li>
+                        <li>Los datos de salud <strong>no se transfieren a terceros</strong> salvo para prestar la función solicitada, ni se usan para publicidad o para vender.</li>
+                        <li>Puedes revocar el acceso en cualquier momento desde Health Connect o desde los ajustes del sistema.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">6. Dónde se almacenan tus datos</h2>
+                    <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-400 p-4 mb-4">
+                        <p class="text-green-800 dark:text-green-200">
+                            <strong>En tu dispositivo:</strong> la mayoría de los datos (historial de ánimo y sueño, último resumen del wearable, caché de la guía del día, preferencias) se guardan localmente mediante la base de datos local de la app y el almacenamiento de preferencias.
+                        </p>
+                    </div>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>Firebase (Authentication y Firestore):</strong> si inicias sesión con tu cuenta, se almacenan tu identificador y datos básicos de perfil para sincronizarlos.</li>
+                        <li><strong>Backend del desarrollador y proveedores de IA/clima:</strong> procesan temporalmente las señales agregadas para devolver la guía o el pronóstico; no se usan para identificarte.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">7. Con quién compartimos datos</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        No vendemos ni alquilamos tus datos personales. Compartimos el mínimo imprescindible con los siguientes <strong>encargados de tratamiento</strong>, únicamente para que la app funcione:
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>Google Firebase</strong> (Authentication, Firestore, Analytics): cuenta, perfil y métricas de uso.</li>
+                        <li><strong>Google Play Billing</strong>: gestión de la suscripción. Google procesa el pago; <strong>no almacenamos datos de tarjetas</strong>.</li>
+                        <li><strong>Proveedor de clima</strong> (a través de nuestro backend): coordenadas aproximadas para el pronóstico.</li>
+                        <li><strong>Proveedor de IA</strong> (Google Gemini u Ollama, a través de nuestro backend): señales agregadas para la guía diaria.</li>
+                    </ul>
+                    <p class="text-gray-700 dark:text-gray-300 mt-2">
+                        También podríamos divulgar datos si la ley lo exige. Los datos de salud nunca se comparten con fines publicitarios.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">8. Conservación y eliminación</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-2">
+                        Conservamos los datos mientras uses la app o mantengas tu cuenta. Puedes eliminar tus datos así:
+                    </p>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li><strong>Datos en el dispositivo:</strong> bórralos desde los Ajustes de la app o desinstalando Aethera.</li>
+                        <li><strong>Acceso a salud:</strong> revoca los permisos en Health Connect o desconecta el wearable desde la app.</li>
+                        <li><strong>Cuenta y datos en Firebase:</strong> escribe a <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a> solicitando la eliminación de tu cuenta y atenderemos la solicitud en un plazo razonable.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">9. Seguridad</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        Aplicamos medidas razonables de seguridad: conexiones cifradas (HTTPS/TLS), fijación de certificados (certificate pinning) hacia nuestro backend, claves de API no embebidas en la app y minimización de datos. Ningún sistema es 100&nbsp;% infalible, pero trabajamos para proteger tu información.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">10. Tus derechos</h2>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Acceder, rectificar o eliminar tus datos.</li>
+                        <li>Retirar tu consentimiento (revocar permisos de salud, ubicación o micrófono).</li>
+                        <li>Oponerte o limitar ciertos tratamientos y solicitar la portabilidad de tus datos.</li>
+                        <li>Presentar una reclamación ante tu autoridad de protección de datos.</li>
+                    </ul>
+                    <p class="text-gray-700 dark:text-gray-300 mt-2">
+                        Para ejercer estos derechos (incluidos los del RGPD en la UE/EEE y la CCPA en California), escríbenos a <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a>.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">11. Transferencias internacionales</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        Algunos proveedores (como Google) pueden procesar datos en servidores ubicados fuera de tu país. En esos casos se aplican las salvaguardas correspondientes previstas por dichos proveedores.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">12. Menores de edad</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        Aethera no está dirigida a menores de 13 años (ni a menores de 16 en el EEE donde aplique). No recopilamos conscientemente datos de menores. Si crees que un menor nos ha proporcionado datos, contáctanos para eliminarlos.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">13. Cambios en esta política</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        Podemos actualizar esta política. Publicaremos los cambios en esta misma URL y actualizaremos la fecha de "Última actualización". Los cambios significativos se comunicarán dentro de la app cuando corresponda.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">14. Contacto</h2>
+                    <div class="bg-gray-50 dark:bg-gray-700 p-6 rounded-lg">
+                        <p class="text-gray-700 dark:text-gray-300 mb-4">
+                            Si tienes preguntas sobre esta política de privacidad o sobre el tratamiento de tus datos:
+                        </p>
+                        <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+                            <li><strong>Email:</strong> <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a></li>
+                            <li><strong>App:</strong> Aethera (<code>com.devguy.aethera</code>)</li>
+                            <li><strong>Términos de uso:</strong> <a href="/devguy/aethera/terms.html" class="text-blue-600 dark:text-blue-400 hover:underline">n33no.online/devguy/aethera/terms.html</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+                        <p class="text-sm text-gray-500 dark:text-gray-400 text-center">
+                            Esta política de privacidad es efectiva a partir del 28 de mayo de 2026.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/public/devguy/aethera/terms-en.html
+++ b/public/devguy/aethera/terms-en.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
+    <title>Terms of Use — Aethera</title>
+    <meta name="description" content="Terms of use for the Aethera app: nature of the service, Aethera Plus subscription, acceptable use and limitation of liability.">
+    <link rel="canonical" href="https://n33no.online/devguy/aethera/terms-en.html">
+    <link rel="alternate" hreflang="es" href="https://n33no.online/devguy/aethera/terms.html">
+    <link rel="alternate" hreflang="en" href="https://n33no.online/devguy/aethera/terms-en.html">
+    <link rel="stylesheet" href="/styles/output.css">
+    <script>
+        if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark')
+        }
+    </script>
+</head>
+<body class="dark:bg-gray-900 antialiased">
+    <div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+
+                <div class="flex items-center justify-between mb-6">
+                    <span class="text-sm font-semibold tracking-wide text-blue-600 dark:text-blue-400 uppercase">Aethera</span>
+                    <a href="/devguy/aethera/terms.html" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">Versión en español</a>
+                </div>
+
+                <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-2">Terms of Use</h1>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                    <strong>Aethera</strong> mobile app (Android) · <code>com.devguy.aethera</code>
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-8">Last updated: May 28, 2026</p>
+
+                <div class="prose prose-lg max-w-none dark:prose-invert">
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">1. Nature of the service</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        Aethera provides <strong>wellness, entertainment and personal reflection</strong> content (biorhythm, numerology, weather, mood and sleep). It <strong>is not a medical application</strong> and does not diagnose, treat or prevent any disease. Always consult a healthcare professional for medical concerns.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">2. Acceptable use</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        You must use the app personally and lawfully. Do not attempt to extract API keys, perform unauthorized decompilation, or abuse cloud service quotas.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">3. Aethera Plus subscription</h2>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Prices, free trials and billing are handled by <strong>Google Play</strong> according to your country.</li>
+                        <li>You can cancel at any time from Google Play → Subscriptions.</li>
+                        <li>Plus features (more AI guidance, extended history, smart notifications) require an active subscription.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">4. Intellectual property</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        The design, text and Aethera brand belong to the app owner. Do not copy or redistribute the application package without authorization.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">5. Limitation of liability</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        The app is provided "as is". We do not guarantee the accuracy of biorhythm, numerology, AI responses or third-party wearable data. Use of the information is at your own risk.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">6. Privacy</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        The processing of your data is governed by our <a href="/devguy/aethera/privacy-policy-en.html" class="text-blue-600 dark:text-blue-400 hover:underline">Privacy Policy</a>.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">7. Contact</h2>
+                    <div class="bg-gray-50 dark:bg-gray-700 p-6 rounded-lg">
+                        <p class="text-gray-700 dark:text-gray-300">
+                            <strong>Support email:</strong> <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/public/devguy/aethera/terms.html
+++ b/public/devguy/aethera/terms.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
+    <title>Términos de Uso — Aethera</title>
+    <meta name="description" content="Términos de uso de la aplicación Aethera: naturaleza del servicio, suscripción Aethera Plus, uso aceptable y limitación de responsabilidad.">
+    <link rel="canonical" href="https://n33no.online/devguy/aethera/terms.html">
+    <link rel="alternate" hreflang="es" href="https://n33no.online/devguy/aethera/terms.html">
+    <link rel="alternate" hreflang="en" href="https://n33no.online/devguy/aethera/terms-en.html">
+    <link rel="stylesheet" href="/styles/output.css">
+    <script>
+        if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+        } else {
+            document.documentElement.classList.remove('dark')
+        }
+    </script>
+</head>
+<body class="dark:bg-gray-900 antialiased">
+    <div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+
+                <div class="flex items-center justify-between mb-6">
+                    <span class="text-sm font-semibold tracking-wide text-blue-600 dark:text-blue-400 uppercase">Aethera</span>
+                    <a href="/devguy/aethera/terms-en.html" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">English version</a>
+                </div>
+
+                <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-2">Términos de Uso</h1>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                    Aplicación móvil <strong>Aethera</strong> (Android) · <code>com.devguy.aethera</code>
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-8">Última actualización: 28 de mayo de 2026</p>
+
+                <div class="prose prose-lg max-w-none dark:prose-invert">
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">1. Naturaleza del servicio</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        Aethera ofrece contenido de <strong>bienestar, entretenimiento y reflexión personal</strong> (biorritmo, numerología, clima, ánimo y sueño). <strong>No es una aplicación médica</strong> y no diagnostica, trata ni previene enfermedades. Consulta siempre a un profesional de la salud ante cualquier duda médica.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">2. Uso aceptable</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        Debes usar la app de forma personal y conforme a la ley. No intentes extraer claves de API, descompilar la app de forma no autorizada ni abusar de las cuotas de los servicios en la nube.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">3. Suscripción Aethera Plus</h2>
+                    <ul class="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                        <li>Los precios, pruebas gratuitas y la facturación los gestiona <strong>Google Play</strong> según tu país.</li>
+                        <li>Puedes cancelar en cualquier momento desde Google Play → Suscripciones.</li>
+                        <li>Las funciones Plus (más guías por IA, historial ampliado, notificaciones inteligentes) requieren una suscripción activa.</li>
+                    </ul>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">4. Propiedad intelectual</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        El diseño, los textos y la marca Aethera pertenecen al titular de la app. No copies ni redistribuyas el paquete de la aplicación sin autorización.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">5. Limitación de responsabilidad</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        La app se ofrece "tal cual". No garantizamos la exactitud del biorritmo, la numerología, las respuestas de IA ni los datos de wearables de terceros. El uso de la información es bajo tu responsabilidad.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">6. Privacidad</h2>
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">
+                        El tratamiento de tus datos se rige por nuestra <a href="/devguy/aethera/privacy-policy.html" class="text-blue-600 dark:text-blue-400 hover:underline">Política de Privacidad</a>.
+                    </p>
+
+                    <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-4">7. Contacto</h2>
+                    <div class="bg-gray-50 dark:bg-gray-700 p-6 rounded-lg">
+                        <p class="text-gray-700 dark:text-gray-300">
+                            <strong>Email de soporte:</strong> <a href="mailto:aarjona1991@gmail.com" class="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991@gmail.com</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -16,19 +16,19 @@
     <meta name="bingbot" content="index, follow">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://aarjona1991.github.io/">
+    <link rel="canonical" href="https://n33no.online/">
     
     <!-- Language Alternates -->
-    <link rel="alternate" hreflang="en" href="https://aarjona1991.github.io/">
-    <link rel="alternate" hreflang="es" href="https://aarjona1991.github.io/?lang=es">
-    <link rel="alternate" hreflang="x-default" href="https://aarjona1991.github.io/">
+    <link rel="alternate" hreflang="en" href="https://n33no.online/">
+    <link rel="alternate" hreflang="es" href="https://n33no.online/?lang=es">
+    <link rel="alternate" hreflang="x-default" href="https://n33no.online/">
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://aarjona1991.github.io/">
+    <meta property="og:url" content="https://n33no.online/">
     <meta property="og:title" content="aarjona1991 - Frontend Developer | React & TypeScript Specialist">
     <meta property="og:description" content="Professional Frontend Developer specialized in React, TypeScript, and modern web technologies. Creating exceptional digital experiences with clean code and innovative solutions.">
-    <meta property="og:image" content="https://aarjona1991.github.io/images/og-image.jpg">
+    <meta property="og:image" content="https://n33no.online/images/og-image.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="aarjona1991 - Frontend Developer Portfolio">
@@ -38,10 +38,10 @@
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:url" content="https://aarjona1991.github.io/">
+    <meta name="twitter:url" content="https://n33no.online/">
     <meta name="twitter:title" content="aarjona1991 - Frontend Developer | React & TypeScript Specialist">
     <meta name="twitter:description" content="Professional Frontend Developer specialized in React, TypeScript, and modern web technologies. Creating exceptional digital experiences with clean code and innovative solutions.">
-    <meta name="twitter:image" content="https://aarjona1991.github.io/images/og-image.jpg">
+    <meta name="twitter:image" content="https://n33no.online/images/og-image.jpg">
     <meta name="twitter:image:alt" content="aarjona1991 - Frontend Developer Portfolio">
     <meta name="twitter:creator" content="@aarjona1991">
     <meta name="twitter:site" content="@aarjona1991">
@@ -59,8 +59,8 @@
         "name": "aarjona1991",
         "jobTitle": "Frontend Developer",
         "description": "Professional Frontend Developer specialized in React, TypeScript, and modern web technologies",
-        "url": "https://aarjona1991.github.io/",
-        "image": "https://aarjona1991.github.io/images/og-image.jpg",
+        "url": "https://n33no.online/",
+        "image": "https://n33no.online/images/og-image.jpg",
         "sameAs": [
             "https://github.com/aarjona1991",
             "https://linkedin.com/in/aarjona1991",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 
 # Sitemap
-Sitemap: https://aarjona1991.github.io/sitemap.xml
+Sitemap: https://n33no.online/sitemap.xml
 
 # Crawl-delay
 Crawl-delay: 1

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,36 +2,64 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>https://aarjona1991.github.io/</loc>
+    <loc>https://n33no.online/</loc>
     <lastmod>2024-01-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://aarjona1991.github.io/"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://aarjona1991.github.io/?lang=es"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://n33no.online/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://n33no.online/?lang=es"/>
   </url>
   <url>
-    <loc>https://aarjona1991.github.io/?lang=es</loc>
+    <loc>https://n33no.online/?lang=es</loc>
     <lastmod>2024-01-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://aarjona1991.github.io/"/>
-    <xhtml:link rel="alternate" hreflang="es" href="https://aarjona1991.github.io/?lang=es"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://n33no.online/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://n33no.online/?lang=es"/>
   </url>
   <url>
-    <loc>https://aarjona1991.github.io/privacy-policy</loc>
+    <loc>https://n33no.online/privacy-policy</loc>
     <lastmod>2024-01-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://aarjona1991.github.io/privacy-policy-es</loc>
+    <loc>https://n33no.online/privacy-policy-es</loc>
     <lastmod>2024-01-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://aarjona1991.github.io/privacy-policy-en</loc>
+    <loc>https://n33no.online/privacy-policy-en</loc>
     <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://n33no.online/devguy/aethera/privacy-policy.html</loc>
+    <lastmod>2026-05-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://n33no.online/devguy/aethera/privacy-policy.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://n33no.online/devguy/aethera/privacy-policy-en.html"/>
+  </url>
+  <url>
+    <loc>https://n33no.online/devguy/aethera/privacy-policy-en.html</loc>
+    <lastmod>2026-05-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://n33no.online/devguy/aethera/privacy-policy.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://n33no.online/devguy/aethera/privacy-policy-en.html"/>
+  </url>
+  <url>
+    <loc>https://n33no.online/devguy/aethera/terms.html</loc>
+    <lastmod>2026-05-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://n33no.online/devguy/aethera/terms-en.html</loc>
+    <lastmod>2026-05-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -145,7 +145,7 @@ const PrivacyPolicy = () => {
                             <ul className="space-y-2 text-gray-700 dark:text-gray-300">
                                 <li><strong>Email:</strong> aarjona1991@gmail.com</li>
                                 <li><strong>GitHub:</strong> <a href="https://github.com/aarjona1991" className="text-blue-600 dark:text-blue-400 hover:underline">@aarjona1991</a></li>
-                                <li><strong>Portfolio:</strong> <a href="/" className="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991.github.io</a></li>
+                                <li><strong>Portfolio:</strong> <a href="/" className="text-blue-600 dark:text-blue-400 hover:underline">n33no.online</a></li>
                             </ul>
                         </div>
 

--- a/src/pages/PrivacyPolicyEN.tsx
+++ b/src/pages/PrivacyPolicyEN.tsx
@@ -160,7 +160,7 @@ const PrivacyPolicyEN = () => {
                             <ul className="space-y-2 text-gray-700 dark:text-gray-300">
                                 <li><strong>Email:</strong> aarjona1991@gmail.com</li>
                                 <li><strong>GitHub:</strong> <a href="https://github.com/aarjona1991" className="text-blue-600 dark:text-blue-400 hover:underline">@aarjona1991</a></li>
-                                <li><strong>Portfolio:</strong> <a href="/" className="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991.github.io</a></li>
+                                <li><strong>Portfolio:</strong> <a href="/" className="text-blue-600 dark:text-blue-400 hover:underline">n33no.online</a></li>
                             </ul>
                         </div>
 

--- a/src/pages/PrivacyPolicyES.tsx
+++ b/src/pages/PrivacyPolicyES.tsx
@@ -160,7 +160,7 @@ const PrivacyPolicyES = () => {
                             <ul className="space-y-2 text-gray-700 dark:text-gray-300">
                                 <li><strong>Email:</strong> aarjona1991@gmail.com</li>
                                 <li><strong>GitHub:</strong> <a href="https://github.com/aarjona1991" className="text-blue-600 dark:text-blue-400 hover:underline">@aarjona1991</a></li>
-                                <li><strong>Portfolio:</strong> <a href="/" className="text-blue-600 dark:text-blue-400 hover:underline">aarjona1991.github.io</a></li>
+                                <li><strong>Portfolio:</strong> <a href="/" className="text-blue-600 dark:text-blue-400 hover:underline">n33no.online</a></li>
                             </ul>
                         </div>
 

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,22 @@
     {
       "src": "/privacy-policy-en",
       "dest": "/public/privacy-policy-en.html"
+    },
+    {
+      "src": "/devguy/aethera/privacy",
+      "dest": "/public/devguy/aethera/privacy-policy.html"
+    },
+    {
+      "src": "/devguy/aethera/privacy-en",
+      "dest": "/public/devguy/aethera/privacy-policy-en.html"
+    },
+    {
+      "src": "/devguy/aethera/terms",
+      "dest": "/public/devguy/aethera/terms.html"
+    },
+    {
+      "src": "/devguy/aethera/terms-en",
+      "dest": "/public/devguy/aethera/terms-en.html"
     }
   ],
   "headers": [


### PR DESCRIPTION
- Add dedicated privacy policy and terms pages (ES/EN) for the Aethera Android app under /devguy/aethera/, aligned with Google Play Health category and Health Connect disclosure requirements
- Configure custom domain via public/CNAME (n33no.online)
- Update site URLs (sitemap, robots, index meta, _config, build-config, _redirects, vercel routes, portfolio privacy pages) to n33no.online
- Keep github.com repo references unchanged